### PR TITLE
Update CISA URLs used in tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,8 +163,8 @@ def test_full_run_no_redirect(capsys):
 def test_full_run_with_redirect(capsys):
     """Validate output for a given URL that has a redirect."""
     expected_output = [
-        "Results for http://rules.ncats.cyber.dhs.gov:",
-        "  Retrieved URL - 'https://rules.ncats.cyber.dhs.gov/'",
+        "Results for http://rules.vm.cyber.dhs.gov:",
+        "  Retrieved URL - 'https://rules.vm.cyber.dhs.gov/'",
         "  Status code - '200'",
         "  Content type - 'text/plain'",
         "  Redirect - True",
@@ -174,7 +174,7 @@ def test_full_run_with_redirect(capsys):
         with patch.object(
             sys,
             "argv",
-            ["bogus", "--show-redirect", "http://rules.ncats.cyber.dhs.gov"],
+            ["bogus", "--show-redirect", "http://rules.vm.cyber.dhs.gov"],
         ):
             return_code = cli.main()
     except SystemExit as sys_exit:

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -242,7 +242,7 @@ def test_hash_url_html_status_404():
 
 def test_hash_url_with_redirect():
     """Test against a URL that redirects and has no content-type parameters."""
-    test_url = "http://rules.ncats.cyber.dhs.gov"
+    test_url = "http://rules.vm.cyber.dhs.gov"
 
     hasher = hash_http_content.UrlHasher(HASH_ALGORITHM)
     result = hasher.hash_url(test_url)


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates some usage of `rules.ncats.cyber.dhs.gov` in tests to its successor, `rules.vm.cyber.dhs.gov`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Now that legacy subdomain `rules.ncats.cyber.dhs.gov` is an alias of the preferred `rules.vm.cyber.dhs.gov` subdomain, I figured we might as well try to eliminate all of our uses of the legacy subdomain.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Running `pytest` after the changes in this PR showed that all tests were passing.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.